### PR TITLE
Add support for importing Sequel Ace connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # TP-Importer
 
-An unofficial way to import existing Sequel Pro connections into TablePlus. 
+An unofficial way to import existing Sequel Pro or Sequel Ace connections into TablePlus. 
 
 ## *Although a backup is created, this script is intended for use on fresh installations of TablePlus and will overwrite any existing connections.*
 
 ### Prerequisites
 * [TablePlus](https://tableplus.io/)
-* [Sequel Pro](https://www.sequelpro.com/)
+* [Sequel Pro](https://www.sequelpro.com/) OR [Sequel Ace](https://github.com/Sequel-Ace/Sequel-Ace)
 * Node
 * NPM or Yarn
 
@@ -26,7 +26,7 @@ $ cd tp-importer
 $ npm install
 ```
 
-Be sure both Sequel Pro and TablePlus are closed and run the script:
+Be sure both Sequel Pro or Sequel Ace and TablePlus are closed and run the script:
 ```
 $ ./tp-importer
 ```

--- a/src/importer.js
+++ b/src/importer.js
@@ -5,9 +5,11 @@ const plist = require('plist');
 const homedir = require('os').homedir();
 
 class Import {
-  
+
   constructor(prompt) {
-    this.sequelProFavorites   = `${homedir}/Library/Application Support/Sequel Pro/Data/Favorites.plist`;
+    this.favoritesToImport = prompt.importFrom === 'sequelpro' ?
+      `${homedir}/Library/Application Support/Sequel Pro/Data/Favorites.plist` :
+      `${homedir}/Library/Containers/com.sequel-ace.sequel-ace/Data/Library/Application Support/Sequel Ace/Data/Favorites.plist`;
     this.tablePlusConnections = `${homedir}/Library/Application Support/com.tinyapp.TablePlus/Data/Connections.plist`;
     this.tablePlusConnectionGroups = `${homedir}/Library/Application Support/com.tinyapp.TablePlus/Data/ConnectionGroups.plist`;
     this.newConnections = [];
@@ -15,7 +17,7 @@ class Import {
 
     if (prompt.confirmContinue) {
       this.backupConnections();
-      this.buildConnections(this.plist(this.sequelProFavorites)["Favorites Root"]["Children"]);
+      this.buildConnections(this.plist(this.favoritesToImport)["Favorites Root"]["Children"]);
       this.createGroups();
       this.mapConnections();
 

--- a/tp-importer
+++ b/tp-importer
@@ -10,6 +10,15 @@ const Import = require('./src/importer');
 
 const questions = [
 	{
+		type: 'list',
+		name: 'importFrom',
+		message: 'Do you want to import from Sequel Pro or Sequel Ace?',
+		choices: ['SequelPro', 'SequelAce',],
+		filter(val) {
+			return val.toLowerCase();
+		},
+	},
+	{
 		type: 'confirm',
 		name: 'confirmContinue',
 		message: 'Please be sure both TablePlus and Sequel Pro are closed. This script is intended for use on a fresh installation of TablePlus and will not bring over any existing connections if you are already using it. Do you wish to continue?',


### PR DESCRIPTION
A lot of people have moved to Sequel Ace. Since it's a fork of Sequel pro the favorites are stored in the exact same way, just in a different folder. So I decided to add a feature to import Sequel Ace connections. 

Tested on my own machine and worked just fine. 